### PR TITLE
poetry lock --check is deprecated

### DIFF
--- a/.github/workflows/linting_controller.yml
+++ b/.github/workflows/linting_controller.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           pwd
           cd controller_function
-          poetry lock --check
+          poetry check --lock
 
       - name: Install dependencies
         shell: bash

--- a/.github/workflows/linting_status.yml
+++ b/.github/workflows/linting_status.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           pwd
           cd status_function
-          poetry lock --check
+          poetry check --lock
 
       - name: Install dependencies
         shell: bash

--- a/.github/workflows/linting_usage.yml
+++ b/.github/workflows/linting_usage.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           pwd
           cd usage_function
-          poetry lock --check
+          poetry check --lock
 
       - name: Install dependencies
         shell: bash


### PR DESCRIPTION
and has been replaced by poetry check --lock.

We may all need to run `poetry self update` to get the latest Poetry version (which has the check command).