### PR TITLE
Status api versions

### DIFF
--- a/status_function/status/__init__.py
+++ b/status_function/status/__init__.py
@@ -160,7 +160,7 @@ def get_principal(
     return None
 
 
-def get_principal_details(principal: Any):
+def get_principal_details(principal: Any) -> dict[str, Any]:
     """Get details of a service principal.
 
     Args:

--- a/status_function/status/auth.py
+++ b/status_function/status/auth.py
@@ -45,7 +45,7 @@ class BearerAuth(requests.auth.AuthBase):
 
         # jwt.encode(), used to create the access token, doesn't support DSA keys
         allowed_type = EllipticCurvePrivateKey | RSAPrivateKey | Ed25519PrivateKey
-        self.private_key: allowed_type = private_key  # type: ignore
+        self.private_key: allowed_type = private_key
 
     def create_access_token(self) -> str:
         """Create an access token for the user to access the API.

--- a/status_function/status/settings.py
+++ b/status_function/status/settings.py
@@ -60,4 +60,4 @@ def get_settings() -> Settings:
     Returns:
         The settings.
     """
-    return Settings()  # type: ignore
+    return Settings()

--- a/status_function/status/wrapper.py
+++ b/status_function/status/wrapper.py
@@ -17,7 +17,7 @@ class CredentialWrapper(BasicTokenAuthentication):
         credential: Optional[DefaultAzureCredential] = None,
         resource_id: str = "https://management.azure.com/.default",
         **kwargs: dict
-    ):
+    ) -> None:
         """Wrap any azure-identity credential to work with SDK.
 
         Applies to credentials that need azure.common.credentials/msrestazure.
@@ -39,12 +39,12 @@ class CredentialWrapper(BasicTokenAuthentication):
             )  # This line edited
         self._policy = BearerTokenCredentialPolicy(credential, resource_id, **kwargs)
 
-    def _make_request(self):
+    def _make_request(self) -> PipelineRequest:
         return PipelineRequest(
             HttpRequest("CredentialWrapper", "https://fakeurl"), PipelineContext(None)
         )
 
-    def set_token(self):
+    def set_token(self) -> None:
         """Ask the azure-core BearerTokenCredentialPolicy policy to get a token.
 
         Using the policy gives us for free the caching system of azure-core.
@@ -61,7 +61,7 @@ class CredentialWrapper(BasicTokenAuthentication):
         token = request.http_request.headers["Authorization"].split(" ", 1)[1]
         self.token = {"access_token": token}
 
-    def signed_session(self, session=None) -> Session:
+    def signed_session(self, session: Optional[Session] = None) -> Session:
         """Sign the session.
 
         Args:

--- a/status_function/tests/mypy.ini
+++ b/status_function/tests/mypy.ini
@@ -1,6 +1,6 @@
 [mypy]
 ignore_missing_imports = True
-check_untyped_defs = True
+disallow_untyped_defs = True
 plugins = pydantic.mypy
 
 [pydantic-mypy]

--- a/status_function/tests/test_function_app.py
+++ b/status_function/tests/test_function_app.py
@@ -34,7 +34,7 @@ EXPECTED_DICT = {
 class TestStatus(TestCase):
     """Tests for the __init__.py file."""
 
-    def test_main(self):
+    def test_main(self) -> None:
         with patch("status.get_all_status") as mock_get_all_status:
             mock_get_all_status.return_value = ["status1", "status2"]
 
@@ -68,7 +68,7 @@ class TestStatus(TestCase):
                             ]
                         )
 
-    def test_send_status(self):
+    def test_send_status(self) -> None:
         example_status = SubscriptionStatus(
             subscription_id=UUID(int=1),
             display_name="sub1",
@@ -131,7 +131,7 @@ class TestStatus(TestCase):
                         timeout=60,
                     )
 
-    def test_get_principal_details_user(self):
+    def test_get_principal_details_user(self) -> None:
         """test get_principal_details returns the expected dictionary of user
         information.
         """
@@ -147,7 +147,7 @@ class TestStatus(TestCase):
         actual = status.get_principal_details(mock_user)
         self.assertDictEqual(actual, expected)
 
-    def test_get_principal_details_service_principal(self):
+    def test_get_principal_details_service_principal(self) -> None:
         """test get_principal_details returns the expected dictionary
         of service principal information
         """
@@ -162,7 +162,7 @@ class TestStatus(TestCase):
         actual = status.get_principal_details(mock_user)
         self.assertDictEqual(actual, expected)
 
-    def test_get_ad_group_principals(self):
+    def test_get_ad_group_principals(self) -> None:
         """Test get_ad_group_principals populates the user details for members."""
         expected = [
             {
@@ -185,7 +185,7 @@ class TestStatus(TestCase):
             actual = status.get_ad_group_principals(mock_ad_group, mgc)
             self.assertListEqual(actual, expected)
 
-    def test_get_role_assignment_models__with_user(self):
+    def test_get_role_assignment_models__with_user(self) -> None:
         """test get_role_assignment_models returns the expected result when
         given a user
         """
@@ -215,7 +215,7 @@ class TestStatus(TestCase):
                     )
                     self.assertListEqual([expected], actual)
 
-    def test_get_role_assignment_models__with_service_principal(self):
+    def test_get_role_assignment_models__with_service_principal(self) -> None:
         """test get_role_assignment_models returns the expected result when
         given a service_principal
         """
@@ -244,7 +244,7 @@ class TestStatus(TestCase):
                     )
                     self.assertListEqual([expected], actual)
 
-    def test_get_role_assignment_models__with_adgroup(self):
+    def test_get_role_assignment_models__with_adgroup(self) -> None:
         """test get_role_assignment_models returns the expected result when
         given an ADGroup
         """
@@ -280,7 +280,7 @@ class TestStatus(TestCase):
                     )
                     self.assertListEqual(expected, actual)
 
-    def test_get_role_assignment_models__with_other_role_assignment(self):
+    def test_get_role_assignment_models__with_other_role_assignment(self) -> None:
         """test get_role_assignment_models returns the expected result when
         given something other than a User, ServicePrincipal or ADGroup
         """
@@ -303,7 +303,7 @@ class TestStatus(TestCase):
                 )
                 self.assertListEqual([expected], actual)
 
-    def test_get_subscription_role_assignment_models__no_error(self):
+    def test_get_subscription_role_assignment_models__no_error(self) -> None:
         """test get_subscription_role_assignment_models returns a list of
         RoleAssignments"""
         mock_subscription = MagicMock()
@@ -336,7 +336,7 @@ class TestStatus(TestCase):
 
     def test_get_subscription_role_assignment_models__cloud_error_returns_empty_list(
         self,
-    ):
+    ) -> None:
         """test get_subscription_role_assignment_models returns an empty list when a
         CloudError occurs
         """
@@ -356,7 +356,7 @@ class TestStatus(TestCase):
                             )
                             self.assertListEqual(actual, [])
 
-    def test_get_all_status(self):
+    def test_get_all_status(self) -> None:
         with patch("status.SubscriptionClient") as mock_sub_client:
             mock_list_func = mock_sub_client.return_value.subscriptions.list
             mock_list_func.return_value = [
@@ -489,7 +489,7 @@ class TestStatus(TestCase):
                         actual = status.get_all_status(UUID(int=1000))
                         self.assertListEqual(expected, actual)
 
-    def test_get_all_status_error_handling(self):
+    def test_get_all_status_error_handling(self) -> None:
         # ToDo Could we make a patch() that incorporates these four patches?
         with patch("status.SubscriptionClient") as mock_sub_client:
             mock_list_func = mock_sub_client.return_value.subscriptions.list
@@ -542,7 +542,7 @@ class TestStatus(TestCase):
 class TestSettings(TestCase):
     """Tests for the status.settings module."""
 
-    def test_key_validation(self):
+    def test_key_validation(self) -> None:
         self.assertRaises(
             ValueError,
             lambda: status.settings.Settings(
@@ -559,7 +559,7 @@ class TestSettings(TestCase):
             ),
         )
 
-    def test_settings(self):
+    def test_settings(self) -> None:
         """Check that we can make a Settings instance, given the right arguments."""
         private_key = rsa.generate_private_key(
             public_exponent=65537,
@@ -581,7 +581,7 @@ class TestSettings(TestCase):
 class TestAuth(TestCase):
     """Tests for the status.auth module."""
 
-    def test_bearer_auth(self):
+    def test_bearer_auth(self) -> None:
         private_key = rsa.generate_private_key(
             public_exponent=65537,
             key_size=2048,
@@ -615,7 +615,7 @@ class TestAuth(TestCase):
 
 
 class TestLoggingUtils(TestCase):
-    def test_called_twice(self):
+    def test_called_twice(self) -> None:
         """Adding multiple loggers could cause large storage bills."""
         with patch("status.settings.get_settings") as mock_get_settings:
             mock_get_settings.return_value.CENTRAL_LOGGING_CONNECTION_STRING = "my-str"


### PR DESCRIPTION
## Summary

For the newer API versions (e.g. the one we're dealing with as of the recent dependency updates), we need to call `auth_client.role_assignments.list_for_subscription()` instead of `auth_client.role_assignments.list()`.

## Detail

The `azure.mgmt.authorization import AuthorizationManagementClient` [decides dynamically](https://github.com/Azure/azure-sdk-for-python/blob/74509c2efa003f2f5328beb000e923804f9a394c/sdk/authorization/azure-mgmt-authorization/azure/mgmt/authorization/_authorization_management_client.py#L781) what version of `role_assignments` it will return based on the api_version passed to the constructor or else a default. This makes it hard for type-checkers to pick up on the change.

This PR:

1. Explicitly requires version `2022-04-01`. There is nothing special about it other than it seems to be the latest stable version.
2. Dynamically loads the right versions of RoleAssignment and RoleAssignmentOperations for use in testing either:
   * directly, as in `MODELS_MODULE.RoleAssignment()`
   * as a spec for Mock, as in `MagicMock(spec=OPERATIONS_MODULE.RoleAssignmentsOperations)`

