### PR TITLE
Fix link in README, which pointed to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Documentation Status](https://readthedocs.org/projects/rctab-functions/badge/?version=latest)](https://rctab-functions.readthedocs.io/en/latest/?badge=latest)
 
 These are the Azure function apps for RCTab.
-You can find the full RCTab docs [here](https://rctab.readthedocs.io/), the online function app documentation [here](https://rctab-cli.readthedocs.io/) and the documentation source code in [docs/](docs/).
+You can find the full RCTab docs [here](https://rctab.readthedocs.io/), the online function app documentation [here](https://rctab-functions.readthedocs.io/) and the documentation source code in [docs/](docs/).
 
 In addition, each of the three functions has its own README:
 


### PR DESCRIPTION
Closes #19 

We had the wrong link (CLI, rather than functions) in the main README.