### PR TITLE
Include seconds part of CRONTAB

### DIFF
--- a/usage_function/monthly_usage/function.json
+++ b/usage_function/monthly_usage/function.json
@@ -3,7 +3,7 @@
     {
       "direction": "in",
       "name": "every_other_hour_on_7th_and_8th",
-      "schedule": "10 0,2,4,6,8,10,12,14,16,18,20,22 7,8 * *",
+      "schedule": "0 10 0,2,4,6,8,10,12,14,16,18,20,22 7,8 * *",
       "type": "timerTrigger"
     }
   ],


### PR DESCRIPTION
Note that Azure functions use [NCRONTAB](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer?tabs=python-v2%2Cisolated-process%2Cnodejs-v4&pivots=programming-language-python#ncrontab-expressions), with a sixth field. Our current CRON expression only has the usual five. This could explain #40 