### PR TITLE
Modern usage detail

### DIFF
--- a/usage_function/tests/test_function_app.py
+++ b/usage_function/tests/test_function_app.py
@@ -72,12 +72,14 @@ class TestUsage(TestCase):
                                     ninth,
                                     ninth,
                                     billing_account_id=None,
+                                    billing_profile_id=None,
                                     mgmt_group="mgmt-group",
                                 ),
                                 call(
                                     eighth,
                                     eighth,
                                     billing_account_id=None,
+                                    billing_profile_id=None,
                                     mgmt_group="mgmt-group",
                                 ),
                             ]

--- a/usage_function/tests/test_utils.py
+++ b/usage_function/tests/test_utils.py
@@ -42,7 +42,70 @@ class DummyAzureUsage:
 class TestUsageUtils(TestCase):
     """Tests for the utils.usage module."""
 
-    def test_get_all_usage(self) -> None:
+    def test_get_all_usage_billing_account(self) -> None:
+        # Mock usage data, for when we patch usage_details.list
+        expected = [1, 2]
+
+        with patch("utils.usage.ConsumptionManagementClient") as mock_client:
+            mock_list_func = mock_client.return_value.usage_details.list
+            mock_list_func.return_value = expected
+
+            jan_tenth = datetime(2021, 1, 10, 1, 1, 1, 1)
+            actual = list(
+                utils.usage.get_all_usage(
+                    jan_tenth - timedelta(days=5),
+                    jan_tenth,
+                    billing_account_id="1:2",
+                )
+            )
+
+            mock_client.assert_called_once_with(
+                credential=utils.usage.CREDENTIALS,
+                subscription_id=str(UUID(int=0)),
+            )
+
+            mock_list_func.assert_called_once_with(
+                scope="/providers/Microsoft.Billing/billingAccounts/1:2",
+                filter="properties/usageEnd ge '2021-01-05T01:01:01Z' and "
+                "properties/usageEnd le '2021-01-10T01:01:01Z'",
+                metric="AmortizedCost",
+            )
+
+        self.assertListEqual(expected, actual)
+
+    def test_get_all_usage_billing_profile(self) -> None:
+        # Mock usage data, for when we patch usage_details.list
+        expected = [1, 2]
+
+        with patch("utils.usage.ConsumptionManagementClient") as mock_client:
+            mock_list_func = mock_client.return_value.usage_details.list
+            mock_list_func.return_value = expected
+
+            jan_tenth = datetime(2021, 1, 10, 1, 1, 1, 1)
+            actual = list(
+                utils.usage.get_all_usage(
+                    jan_tenth - timedelta(days=5),
+                    jan_tenth,
+                    billing_account_id="1:2",
+                    billing_profile_id="3",
+                )
+            )
+
+            mock_client.assert_called_once_with(
+                credential=utils.usage.CREDENTIALS,
+                subscription_id=str(UUID(int=0)),
+            )
+
+            mock_list_func.assert_called_once_with(
+                scope="/providers/Microsoft.Billing/billingAccounts/1:2/billingProfiles/3",
+                filter="properties/usageEnd ge '2021-01-05T01:01:01Z' and "
+                "properties/usageEnd le '2021-01-10T01:01:01Z'",
+                metric="AmortizedCost",
+            )
+
+        self.assertListEqual(expected, actual)
+
+    def test_get_all_usage_mgmt_group(self) -> None:
         # Mock usage data, for when we patch usage_details.list
         expected = [1, 2]
 
@@ -618,6 +681,18 @@ class TestSettings(TestCase):
             utils.settings.Settings(
                 PRIVATE_KEY=self.private_key_str,
                 API_URL=HTTP_ADAPTER.validate_python("https://my.host"),
+                _env_file=None,
+            )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "BILLING_PROFILE_ID is only valid with a BILLING_ACCOUNT_ID.",
+        ):
+            utils.settings.Settings(
+                PRIVATE_KEY=self.private_key_str,
+                API_URL=HTTP_ADAPTER.validate_python("https://my.host"),
+                MGMT_GROUP="x",
+                BILLING_PROFILE_ID="y",
                 _env_file=None,
             )
 

--- a/usage_function/tests/test_utils.py
+++ b/usage_function/tests/test_utils.py
@@ -7,6 +7,7 @@ from unittest import TestCase, main
 from unittest.mock import MagicMock, call, patch
 from uuid import UUID
 
+from azure.mgmt.consumption.models import ModernUsageDetail
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from pydantic import HttpUrl, TypeAdapter
@@ -331,6 +332,44 @@ class TestUsageUtils(TestCase):
         )
 
         self.assertListEqual([expected_item_1, expected_item_2], actual)
+
+    def test_retrieve_usage_modern_usage_detail(self) -> None:
+        """Check retrieve_usage can handle modern usage detail objects."""
+        modern_usage_1 = ModernUsageDetail()
+        modern_usage_1.id = "1"
+        modern_usage_1.subscription_guid = str(UUID(int=0))
+        modern_usage_1.date = date.today()
+        modern_usage_1.quantity = 1
+        modern_usage_1.cost_in_billing_currency = 1
+        modern_usage_1.unit_price = 1
+        modern_usage_1.effective_price = 1
+        modern_usage_1.billing_currency_code = "GBP"
+
+        modern_usage_2 = ModernUsageDetail()
+        modern_usage_2.id = "1"
+        modern_usage_2.subscription_guid = str(UUID(int=0))
+        modern_usage_2.date = date.today()
+        modern_usage_2.quantity = 1
+        modern_usage_2.cost_in_billing_currency = 1
+        modern_usage_2.unit_price = 1
+        modern_usage_2.effective_price = 1
+        modern_usage_2.billing_currency_code = "GBP"
+
+        actual = utils.usage.retrieve_usage([modern_usage_1, modern_usage_2])  # type: ignore[arg-type]
+        expected = models.Usage(
+            id="1",
+            subscription_id=UUID(int=0),
+            quantity=2,
+            cost=2,
+            date=date.today(),
+            amortised_cost=0,
+            total_cost=2,
+            unit_price=2,
+            effective_price=2,
+            billing_currency="GBP",
+        )
+
+        self.assertListEqual([expected], actual)
 
     def test_date_range(self) -> None:
         start = datetime(year=2021, month=11, day=1, hour=2)

--- a/usage_function/usage/__init__.py
+++ b/usage_function/usage/__init__.py
@@ -54,6 +54,7 @@ def main(mytimer: func.TimerRequest) -> None:
                 usage_date,
                 usage_date,
                 billing_account_id=config.BILLING_ACCOUNT_ID,
+                billing_profile_id=config.BILLING_PROFILE_ID,
                 mgmt_group=config.MGMT_GROUP,
             )
 

--- a/usage_function/utils/settings.py
+++ b/usage_function/utils/settings.py
@@ -19,8 +19,9 @@ class Settings(BaseSettings):
     CM_MGMT_GROUP: Optional[str] = None  # The cost management function mgmt group
     MGMT_GROUP: Optional[str] = None  # Either, the usage function mgmt group...
     BILLING_ACCOUNT_ID: Optional[str] = (
-        None  # ...or the usage function billing account ID
+        None  # ...or the usage function billing account ID, with an optional...
     )
+    BILLING_PROFILE_ID: Optional[str] = None  # ...billing profile ID.
     CENTRAL_LOGGING_CONNECTION_STRING: Optional[str] = None
 
     # Settings for the settings class itself.
@@ -56,6 +57,11 @@ class Settings(BaseSettings):
         ):
             raise ValueError(
                 "Exactly one of MGMT_GROUP and BILLING_ACCOUNT_ID should be empty."
+            )
+
+        if self.BILLING_PROFILE_ID and not self.BILLING_ACCOUNT_ID:
+            raise ValueError(
+                "BILLING_PROFILE_ID is only valid with a BILLING_ACCOUNT_ID."
             )
 
         return self

--- a/usage_function/utils/usage.py
+++ b/usage_function/utils/usage.py
@@ -37,6 +37,7 @@ def get_all_usage(
     start_time: datetime,
     end_time: datetime,
     billing_account_id: Optional[str] = None,
+    billing_profile_id: Optional[str] = None,
     mgmt_group: Optional[str] = None,
 ) -> Iterable[UsageDetail]:
     """Get Azure usage data for a subscription between start_time and end_time.
@@ -45,6 +46,7 @@ def get_all_usage(
         start_time: Start time.
         end_time: End time.
         billing_account_id: Billing Account ID.
+        billing_profile_id: Billing Profile ID.
         mgmt_group: The name of a management group.
     """
     # It doesn't matter which subscription ID we use for this bit.
@@ -68,6 +70,8 @@ def get_all_usage(
         scope_expression = (
             f"/providers/Microsoft.Billing/billingAccounts/{billing_account_id}"
         )
+        if billing_profile_id:
+            scope_expression += f"/billingProfiles/{billing_profile_id}"
     elif mgmt_group:
         scope_expression = (
             f"/providers/Microsoft.Management/managementGroups/{mgmt_group}"

--- a/usage_function/utils/usage.py
+++ b/usage_function/utils/usage.py
@@ -4,13 +4,16 @@ import copy
 import logging
 from datetime import date, datetime, timedelta
 from functools import lru_cache
-from typing import Generator, Iterable, Optional
+from typing import Generator, Iterable, Optional, cast
 from uuid import UUID
 
 import requests
 from azure.identity import DefaultAzureCredential
 from azure.mgmt.consumption import ConsumptionManagementClient
-from azure.mgmt.consumption.models import UsageDetailsListResult, UsageDetail
+from azure.mgmt.consumption.models import (
+    ModernUsageDetail,
+    UsageDetail,
+)
 from pydantic import HttpUrl
 from rctab_models import models
 
@@ -38,7 +41,7 @@ def get_all_usage(
     end_time: datetime,
     billing_account_id: Optional[str] = None,
     mgmt_group: Optional[str] = None,
-) -> Iterable[UsageDetailsListResult]:
+) -> Iterable[UsageDetail]:
     """Get Azure usage data for a subscription between start_time and end_time.
 
     Args:
@@ -83,7 +86,9 @@ def get_all_usage(
         scope=scope_expression, filter=filter_expression, metric=metric_expression
     )
 
-    return data
+    # Azure SDK typing here is too broad/inaccurate: list() actually iterates
+    # UsageDetail items (legacy or modern), not UsageDetailsListResult wrappers.
+    return cast(Iterable[UsageDetail], data)
 
 
 def combine_items(item_to_update: models.Usage, other_item: models.Usage) -> None:
@@ -144,6 +149,14 @@ def usage_detail_to_usage_model(detail: UsageDetail) -> models.Usage:
     """Convert a Legacy or Modern UsageDetail to a Usage model."""
     item_dict = dict(vars(detail))
 
+    if isinstance(detail, ModernUsageDetail):
+        # Align modern usage naming with the legacy-shaped rctab Usage model.
+        # We intentionally use billed local currency cost, not USD cost.
+        item_dict["subscription_id"] = item_dict["subscription_guid"]
+        item_dict["cost"] = item_dict["cost_in_billing_currency"]
+        item_dict["billing_currency"] = item_dict["billing_currency_code"]
+        item_dict["invoice_section"] = item_dict.get("invoice_section_name")
+
     # When AmortizedCost metric is being used, the cost and effective_price values
     # for reserved instances are not zero, thus the cost value is moved to
     # amortised_cost
@@ -161,7 +174,7 @@ def usage_detail_to_usage_model(detail: UsageDetail) -> models.Usage:
 
 
 def retrieve_usage(
-    usage_data: Iterable[UsageDetailsListResult],
+    usage_data: Iterable[UsageDetail],
 ) -> list[models.Usage]:
     """Retrieve usage data from Azure.
 
@@ -195,7 +208,7 @@ def retrieve_usage(
 
 def retrieve_and_send_usage(
     hostname_or_ip: HttpUrl,
-    usage_data: Iterable[UsageDetailsListResult],
+    usage_data: Iterable[UsageDetail],
     start_date: date,
     end_date: date,
 ) -> None:

--- a/usage_function/utils/usage.py
+++ b/usage_function/utils/usage.py
@@ -10,10 +10,7 @@ from uuid import UUID
 import requests
 from azure.identity import DefaultAzureCredential
 from azure.mgmt.consumption import ConsumptionManagementClient
-from azure.mgmt.consumption.models import (
-    ModernUsageDetail,
-    UsageDetail,
-)
+from azure.mgmt.consumption.models import ModernUsageDetail, UsageDetail
 from pydantic import HttpUrl
 from rctab_models import models
 

--- a/usage_function/utils/usage.py
+++ b/usage_function/utils/usage.py
@@ -10,7 +10,7 @@ from uuid import UUID
 import requests
 from azure.identity import DefaultAzureCredential
 from azure.mgmt.consumption import ConsumptionManagementClient
-from azure.mgmt.consumption.models import UsageDetailsListResult
+from azure.mgmt.consumption.models import UsageDetailsListResult, UsageDetail
 from pydantic import HttpUrl
 from rctab_models import models
 
@@ -140,6 +140,26 @@ def compress_items(items: list[models.Usage]) -> list[models.Usage]:
     return ret_list
 
 
+def usage_detail_to_usage_model(detail: UsageDetail) -> models.Usage:
+    """Convert a Legacy or Modern UsageDetail to a Usage model."""
+    item_dict = dict(vars(detail))
+
+    # When AmortizedCost metric is being used, the cost and effective_price values
+    # for reserved instances are not zero, thus the cost value is moved to
+    # amortised_cost
+    item_dict["total_cost"] = item_dict["cost"]
+
+    usage_item = models.Usage(**item_dict)
+
+    if usage_item.reservation_id is not None:
+        usage_item.amortised_cost = usage_item.cost
+        usage_item.cost = 0.0
+    else:
+        usage_item.amortised_cost = 0.0
+
+    return usage_item
+
+
 def retrieve_usage(
     usage_data: Iterable[UsageDetailsListResult],
 ) -> list[models.Usage]:
@@ -160,22 +180,7 @@ def retrieve_usage(
         if i % 200 == 0:
             logging.warning("Requesting item %d", i)
 
-        item_dict = dict(vars(item))
-
-        # When AmortizedCost metric is being used, the cost and effective_price values
-        # for reserved instances are not zero, thus the cost value is moved to
-        # amortised_cost
-        item_dict["total_cost"] = item_dict["cost"]
-
-        usage_item = models.Usage(**item_dict)
-
-        if usage_item.reservation_id is not None:
-            usage_item.amortised_cost = usage_item.cost
-            usage_item.cost = 0.0
-        else:
-            usage_item.amortised_cost = 0.0
-
-        all_items.append(usage_item)
+        all_items.append(usage_detail_to_usage_model(item))
 
     combined_items = compress_items(all_items)
 


### PR DESCRIPTION
The important change is to handle modern usage detail objects. Queries with a management group scope get a list of LegacyUsageDetails, whereas those using a new style UUID:UUID billing profile Id scope will get ModernUsageDetails. 

For now, we'll make the modern details fit the pre-existing Usage model (and table) but might want to change the table schema long-term.

