### PR TITLE
Truncate more modern usage datetimes

### DIFF
--- a/usage_function/tests/test_utils.py
+++ b/usage_function/tests/test_utils.py
@@ -481,7 +481,16 @@ class TestUsageUtils(TestCase):
         modern_usage = ModernUsageDetail()
         modern_usage.id = "1"
         modern_usage.subscription_guid = str(UUID(int=0))
+
+        # Note we truncate these dates.
         modern_usage.date = datetime(year=2021, month=11, day=1, hour=2)
+        modern_usage.billing_period_start_date = datetime(
+            year=2021, month=11, day=2, hour=2
+        )
+        modern_usage.billing_period_end_date = datetime(
+            year=2021, month=11, day=3, hour=2
+        )
+
         modern_usage.quantity = 1
         modern_usage.cost_in_billing_currency = 1
         modern_usage.unit_price = 1
@@ -494,6 +503,8 @@ class TestUsageUtils(TestCase):
                 id="1",
                 subscription_id=UUID(int=0),
                 date=date(year=2021, month=11, day=1),
+                billing_period_start_date=datetime(year=2021, month=11, day=2),
+                billing_period_end_date=datetime(year=2021, month=11, day=3),
                 total_cost=1,
                 cost=1,
                 amortised_cost=0,

--- a/usage_function/utils/usage.py
+++ b/usage_function/utils/usage.py
@@ -173,6 +173,12 @@ def usage_detail_to_usage_model(detail: UsageDetail) -> models.Usage:
         item_dict["date"] = item_dict["date"].replace(
             hour=0, minute=0, second=0, microsecond=0
         )
+        item_dict["billing_period_start_date"] = item_dict[
+            "billing_period_start_date"
+        ].replace(hour=0, minute=0, second=0, microsecond=0)
+        item_dict["billing_period_end_date"] = item_dict[
+            "billing_period_end_date"
+        ].replace(hour=0, minute=0, second=0, microsecond=0)
         usage_item = models.Usage(**item_dict)
 
     if usage_item.reservation_id is not None:


### PR DESCRIPTION
Truncate more than just the Usage.date. We also have to truncate the billing period start and end dates.