### PR TITLE
Revert "Switch to asyncio.run"

### DIFF
--- a/status_function/status/__init__.py
+++ b/status_function/status/__init__.py
@@ -173,7 +173,15 @@ def get_graph_user(user_id: str, client: GraphServiceClient) -> User | None:
         The user object.
     """
     try:
-        return asyncio.run(client.users.by_user_id(user_id).get())
+        # It seems as though Azure runs us in a thread and the default
+        # policy is for only the main thread to have a ready-made loop.
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+    try:
+        return loop.run_until_complete(client.users.by_user_id(user_id).get())
     except APIError as e:
         logger.warning(e)
         return None
@@ -193,9 +201,19 @@ def get_graph_group_members(
         An object containing the members of the group in its value attribute.
     """
     try:
+        # It seems as though Azure runs us in a thread and the default
+        # policy is for only the main thread to have a ready-made loop.
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+    try:
         # Note that this is a paginated response,
         # and will only return the first 100 results.
-        return asyncio.run(client.groups.by_group_id(group_id).members.get())
+        return loop.run_until_complete(
+            client.groups.by_group_id(group_id).members.get()
+        )
     except APIError as e:
         logger.warning(e)
         return None
@@ -215,7 +233,15 @@ def get_graph_service_principal(
         The service principal object.
     """
     try:
-        return asyncio.run(
+        # It seems as though Azure runs us in a thread and the default
+        # policy is for only the main thread to have a ready-made loop.
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+    try:
+        return loop.run_until_complete(
             client.service_principals.by_service_principal_id(
                 service_principal_id
             ).get()


### PR DESCRIPTION
This reverts commit a0a782675ec7afcd51032f004ad8d453872b51a4.

The commit results in the error:

```text
Exception while executing function: Functions.status Result: Failure
Type: 
Exception: RuntimeError: Event loop is closed
Stack: Traceback (most recent call last):
  File "/azure-functions-host/workers/python/3.12/LINUX/X64/azure_functions_worker/dispatcher.py", line 685, in _handle__invocation_request
    call_result = await self._loop.run_in_executor(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/azure-functions-host/workers/python/3.12/LINUX/X64/azure_functions_worker/dispatcher.py", line 1019, in _run_sync_func
    return ExtensionManager.get_sync_invocation_wrapper(context,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/azure-functions-host/workers/python/3.12/LINUX/X64/azure_functions_worker/extension.py", line 211, in _raw_invocation_wrapper
    result = function(**args)
             ^^^^^^^^^^^^^^^^
  File "/home/site/wwwroot/status/__init__.py", line 365, in main
    status = get_all_status()
             ^^^^^^^^^^^^^^^^
  File "/home/site/wwwroot/status/__init__.py", line 324, in get_all_status
    role_assignments_models = get_subscription_role_assignment_models(
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/site/wwwroot/status/__init__.py", line 291, in get_subscription_role_assignment_models
    role_assignments_models += get_role_assignment_models(
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/site/wwwroot/status/__init__.py", line 244, in get_role_assignment_models
    user = get_graph_user(assignment.principal_id, graph_client)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/site/wwwroot/status/__init__.py", line 176, in get_graph_user
    return asyncio.run(client.users.by_user_id(user_id).get())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/asyncio/runners.py", line 195, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/asyncio/base_events.py", line 691, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/site-packages/msgraph/generated/users/item/user_item_request_builder.py", line 166, in get
    return await self.request_adapter.send_async(request_info, User, error_mapping)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/site-packages/kiota_http/httpx_request_adapter.py", line 184, in send_async
    response = await self.get_http_response_message(request_info, parent_span)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/site-packages/kiota_http/httpx_request_adapter.py", line 600, in get_http_response_message
    resp = await self._http_client.send(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/site-packages/httpx/_client.py", line 1629, in send
    response = await self._send_handling_auth(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
    response = await self._send_handling_redirects(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
    response = await self._send_single_request(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/site-packages/httpx/_client.py", line 1730, in _send_single_request
    response = await transport.handle_async_request(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/site-packages/msgraph_core/middleware/async_graph_transport.py", line 21, in handle_async_request
    response = await self.pipeline.send(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/site-packages/kiota_http/middleware/middleware.py", line 37, in send
    return await self._first_middleware.send(request, self._transport)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/site-packages/kiota_http/middleware/redirect_handler.py", line 77, in send
    response = await super().send(request, transport)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/site-packages/kiota_http/middleware/middleware.py", line 64, in send
    return await self.next.send(request, transport)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/site-packages/kiota_http/middleware/retry_handler.py", line 81, in send
    response = await super().send(request, transport)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/site-packages/kiota_http/middleware/middleware.py", line 64, in send
    return await self.next.send(request, transport)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/site-packages/kiota_http/middleware/parameters_name_decoding_handler.py", line 60, in send
    response = await super().send(request, transport)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/site-packages/kiota_http/middleware/middleware.py", line 64, in send
    return await self.next.send(request, transport)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/site-packages/kiota_http/middleware/url_replace_handler.py", line 45, in send
    response = await super().send(request, transport)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/site-packages/kiota_http/middleware/middleware.py", line 64, in send
    return await self.next.send(request, transport)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/site-packages/kiota_http/middleware/user_agent_handler.py", line 30, in send
    return await super().send(request, transport)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/site-packages/kiota_http/middleware/middleware.py", line 64, in send
    return await self.next.send(request, transport)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/site-packages/kiota_http/middleware/headers_inspection_handler.py", line 55, in send
    response = await super().send(request, transport)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/site-packages/kiota_http/middleware/middleware.py", line 64, in send
    return await self.next.send(request, transport)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/site-packages/msgraph_core/middleware/telemetry.py", line 48, in send
    response = await super().send(request, transport)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/site-packages/kiota_http/middleware/middleware.py", line 61, in send
    response = await transport.handle_async_request(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/site-packages/httpx/_transports/default.py", line 394, in handle_async_request
    resp = await self._pool.handle_async_request(req)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 256, in handle_async_request
    raise exc from None
  File "/opt/python/3/lib/python3.12/site-packages/httpcore/_async/connection_pool.py", line 236, in handle_async_request
    response = await connection.handle_async_request(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/site-packages/httpcore/_async/connection.py", line 103, in handle_async_request
    return await self._connection.handle_async_request(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/3/lib/python3.12/site-packages/httpcore/_async/http11.py", line 135, in handle_async_request
    await self._response_closed()
  File "/opt/python/3/lib/python3.12/site-packages/httpcore/_async/http11.py", line 250, in _response_closed
    await self.aclose()
  File "/opt/python/3/lib/python3.12/site-packages/httpcore/_async/http11.py", line 258, in aclose
    await self._network_stream.aclose()
  File "/opt/python/3/lib/python3.12/site-packages/httpcore/_backends/anyio.py", line 53, in aclose
    await self._stream.aclose()
  File "/opt/python/3/lib/python3.12/site-packages/anyio/streams/tls.py", line 236, in aclose
    await self.transport_stream.aclose()
  File "/opt/python/3/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 1374, in aclose
    self._transport.close()
  File "/opt/python/3/lib/python3.12/asyncio/selector_events.py", line 1213, in close
    super().close()
  File "/opt/python/3/lib/python3.12/asyncio/selector_events.py", line 875, in close
    self._loop.call_soon(self._call_connection_lost, None)
  File "/opt/python/3/lib/python3.12/asyncio/base_events.py", line 799, in call_soon
    self._check_closed()
  File "/opt/python/3/lib/python3.12/asyncio/base_events.py", line 545, in _check_closed
    raise RuntimeError('Event loop is closed')
RuntimeError: Event loop is closed
```

I do not understand why we get that specific error. My attempts to reproduce it in a non-trivial manner actually result in `RuntimeError: no running event loop`.